### PR TITLE
Fix for sending uuid on validating response token-Heero

### DIFF
--- a/lib/connectors/openid.js
+++ b/lib/connectors/openid.js
@@ -4,8 +4,7 @@
  * authority levels as specified at the auth server
  * Also includes code to grant and refresh access tokens for a user
  */
-module.exports = function(openIdConfiguration, scimConfiguration = {})
-{
+module.exports = function (openIdConfiguration, scimConfiguration = {}) {
   const httpError = require("http-errors");
 
   const { Issuer } = require("openid-client");
@@ -39,7 +38,7 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
      * @param next
      * @param scope
      */
-    authorize: function(
+    authorize: function (
       request,
       response,
       next,
@@ -71,9 +70,10 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
             // Set introspectionResponse to response locals
             // This can be consumed by the rest of this request chain
             response.locals.authx = introspectionResponse;
-            // we have kept this for temporary purpose. we will remove this part once basic email component is tested.
-            response.locals.authx.uuid = "@!396C.64AD.5710.AFDD!0001!DD6C.CB25!0000!EDF7.E41D.F463.81F5";
-            next();
+            openIdClient.userinfo(token).then((userInfo) => {
+              response.locals.authx.uuid = userInfo.inum;
+              next();
+            });
           }
         })
         .catch(error => {
@@ -81,7 +81,7 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
           // indicates that access was denied
           if (
             error.name == "OpenIdConnectError" &&
-              !!error.message.match(/^access_denied/)
+            !!error.message.match(/^access_denied/)
           ) {
             return next(
               new httpError.Unauthorized("Access denied", {
@@ -116,10 +116,9 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
      *   expires_at: 1535557379,
      *   refresh_token: '845341ae-3112-47ad-855f-625c3b5d693d' }
      */
-    getAccessToken: function(username, password)
-    {
+    getAccessToken: function (username, password) {
       return openIdClient.grant({
-        username: username, 
+        username: username,
         password: password,
         grant_type: 'password',
         scope: 'uma_protection profile'
@@ -136,8 +135,7 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
      *
      * @return A Promise that resolves into a valid tokenSet object
      */
-    ensureAccessToken: function(tokenSet)
-    {
+    ensureAccessToken: function (tokenSet) {
       const moment = require('moment');
       const _this = this;
 
@@ -145,8 +143,7 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
         // Check if the token set is still valid
         // Consider a 5 second window before the token expires so that it's not a last minute
         // request
-        if(moment(moment.now() + 5000).isBefore(moment(tokenSet.expires_at * 1000)))
-        {
+        if (moment(moment.now() + 5000).isBefore(moment(tokenSet.expires_at * 1000))) {
           console.log('Token is still valid. Returning it as is.');
           // Return the same tokenSet
           resolve(tokenSet);
@@ -154,20 +151,18 @@ module.exports = function(openIdConfiguration, scimConfiguration = {})
         {
           console.log('Token has expired. Refreshing it.');
           openIdClient.refresh(tokenSet.refresh_token)
-          .then(tokenSet => resolve(tokenSet))
-          .catch(error => {
-            console.log('Could not refresh token. Attempting to reissue it.');
-            if(!!scimConfiguration && !!scimConfiguration.username && !!scimConfiguration.password)
-            {
-              resolve(_this.getAccessToken(scimConfiguration.username,
-                                   scimConfiguration.password)
-                    );
-            }
-            else
-            {
-              reject(error);
-            }
-          });
+            .then(tokenSet => resolve(tokenSet))
+            .catch(error => {
+              console.log('Could not refresh token. Attempting to reissue it.');
+              if (!!scimConfiguration && !!scimConfiguration.username && !!scimConfiguration.password) {
+                resolve(_this.getAccessToken(scimConfiguration.username,
+                  scimConfiguration.password)
+                );
+              }
+              else {
+                reject(error);
+              }
+            });
         } // else
       }); // Promise
     }, // ensureAccessToken


### PR DESCRIPTION
This PR include: sending UUID as a response on the token introspection API.
